### PR TITLE
feat: Add comprehensive installation logging

### DIFF
--- a/installers/configure_system.sh
+++ b/installers/configure_system.sh
@@ -49,7 +49,7 @@ END
 	if [[ $(sysctl net.ipv4.ip_forward | awk -F'= ' '{print $2}') -eq 0 ]]; then
 		echo 1 > /proc/sys/net/ipv4/ip_forward
 		echo "net.ipv4.ip_forward=1" >> /etc/sysctl.d/custom.conf
-		sysctl -p /etc/sysctl.d/custom.conf &> /dev/null
+		sysctl -p /etc/sysctl.d/custom.conf
 	fi
 
 	timedatectl set-timezone Asia/Manila

--- a/installers/finalize.sh
+++ b/installers/finalize.sh
@@ -10,8 +10,8 @@ _echo_info "Firing up services..."
 SERVICE_NAME=(dropbear squid privoxy ziproxy nginx stunnel4 webmin openvpn-server@server_tcp openvpn-server@server_udp badvpn-udpgw fail2ban)
 systemctl daemon-reload
 for service in "${SERVICE_NAME[@]}"; do
-	systemctl enable "$service" &>/dev/null
-	systemctl restart "$service" &>/dev/null
+	systemctl enable "$service"
+	systemctl restart "$service"
 done
 
 RULES="/etc/iptables/rules.v4"
@@ -22,5 +22,5 @@ iptables-save > "$RULES"
 [[ $(grep -c -- "-A FORWARD -s 10.8.0.0/16 -j ACCEPT" "$RULES") -eq 0 ]] && iptables -A FORWARD -s 10.8.0.0/16 -j ACCEPT
 
 iptables-save > "$RULES"
-netfilter-persistent save &> /dev/null
-systemctl enable netfilter-persistent &> /dev/null
+netfilter-persistent save
+systemctl enable netfilter-persistent

--- a/installers/install_openvpn.sh
+++ b/installers/install_openvpn.sh
@@ -23,7 +23,7 @@ _openvpn() {
 
 	for item in "server_tcp" "server_udp"; do
 		wget -qO /etc/openvpn/server/"$item".conf "$REPO_BASE_URL"/configs/openvpn/"$item".conf
-		printf "\nplugin %s /etc/pam.d/login" "$(find /usr -name openvpn-plugin-auth-pam.so | head -1)" | tee -a /etc/openvpn/server/"$item".conf &>/dev/null
+		printf "\nplugin %s /etc/pam.d/login" "$(find /usr -name openvpn-plugin-auth-pam.so | head -1)" | tee -a /etc/openvpn/server/"$item".conf
 		sed -i "s/OVPN_TCP_PORT/${OVPN_TCP_PORT}/;s/OVPN_UDP_PORT/${OVPN_UDP_PORT}/" /etc/openvpn/server/"$item".conf
 
 		rm -f /lib/systemd/system/openvpn-server@"$item".service

--- a/settings.conf
+++ b/settings.conf
@@ -37,3 +37,8 @@ NGINX_PORT='85'
 
 # Badvpn (udpgw) Port
 BADVPN_PORT='7300'
+
+# --- Logging Settings ---
+
+# Full path to the installation log file.
+LOG_FILE="/var/log/vps2vpn_install.log"

--- a/vps2vpn
+++ b/vps2vpn
@@ -41,6 +41,14 @@ echo "================================================="
 echo
 read -rp " Proceed with installation? [Y/n]: "
 [[ $REPLY =~ [nN] ]] && echo " Installation cancelled, exiting..." && exit
+
+# --- Setup Logging ---
+touch "$LOG_FILE"
+chmod 644 "$LOG_FILE"
+_echo_info "Full installation log will be available in: $LOG_FILE"
+sleep 3
+exec &> >(tee -a "$LOG_FILE")
+
 export DEBIAN_FRONTEND=noninteractive
 T1="$(date +%s)"
 


### PR DESCRIPTION
Implement a logging system to capture the entire output of the installation process.

- A new `LOG_FILE` variable is added to `settings.conf` to allow for easy configuration of the log file path.
- The main `vps2vpn` script now uses `exec` and `tee` to redirect all stdout and stderr to both the console and the specified log file. This allows the user to monitor the installation in real-time while also having a complete record for debugging.
- All instances of output suppression (e.g., `&>/dev/null`) have been removed from the installer scripts to ensure all output is captured.