### PR TITLE
chore: Add verbose debugging to badvpn and fail2ban installers

### DIFF
--- a/installers/install_badvpn.sh
+++ b/installers/install_badvpn.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Enable verbose debugging
+set -x
+
 # This script installs Badvpn.
 # It is called by the main vps2vpn script.
 

--- a/installers/install_fail2ban.sh
+++ b/installers/install_fail2ban.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Enable verbose debugging
+set -x
+
 # This script installs Fail2ban.
 # It is called by the main vps2vpn script.
 


### PR DESCRIPTION
Add `set -x` to the `install_badvpn.sh` and `install_fail2ban.sh` scripts.

This is a temporary debugging step to diagnose an issue where the main script appears to hang while waiting for background jobs. The verbose output will help pinpoint the exact command that is causing the problem.